### PR TITLE
Changed the copy pattern.

### DIFF
--- a/lib/before-prepare.js
+++ b/lib/before-prepare.js
@@ -13,7 +13,7 @@ module.exports = function(logger, platformsData, projectData, hookArgs) {
     });
 
     gulp.task('move:tests', function() {
-      return gulp.src(appFolderPath + '/**/*.spec.js')
+      return gulp.src(appFolderPath + '/**/*.js')
         .pipe(gulp.dest(appFolderPath + '/tests/'))
     });
 


### PR DESCRIPTION
I want to use your hook to maintain our folder structure according to the Angular style guide.

However, this is  something I can't use and I don't think it will benefit others. 
```typescript
import { MyFeatureComponent } from '~/myFeature/myFeature.component';
import { AppComponent } from '~/app.component';
```
TypeScript complains about the imports and this method takes away the advantage of auto-imports. The trade off here is that we copy the complete source, but that keeps all our 500+ unit tests in tact :). Thoughts?