### PR TITLE
Update before-prepare.js

### DIFF
--- a/lib/before-prepare.js
+++ b/lib/before-prepare.js
@@ -4,7 +4,7 @@ var gulp = require('gulp'),
     path = require('path');
 
 module.exports = function(logger, platformsData, projectData, hookArgs) {
-  var appFolderPath = path.join(projectData.projectDir, 'app');
+  var appFolderPath = path.join(projectData.projectDir, 'src');
 
   return new Promise(function(resolve, reject) {
 


### PR DESCRIPTION
Changed appFolderPath string from 'app' to 'src' to match new CLI file structure.

This is a breaking change, so should be a major version release and have a note in the docs about which version to use for which folder structure.